### PR TITLE
Feature/add support for git dependency resolver

### DIFF
--- a/src/depWalker.js
+++ b/src/depWalker.js
@@ -52,7 +52,7 @@ export async function* searchDeepDependencies(packageName, gitURL, options) {
 
     const gitDependencies = iter.filter(customResolvers.entries(), ([, valueStr]) => isGitDependency(valueStr));
     for (const [depName, valueStr] of gitDependencies) {
-      yield* searchDeepDependencies(depName, valueStr.slice(4), config);
+      yield* searchDeepDependencies(depName, valueStr, config);
     }
 
     const depsNames = await Promise.all(iter.map(dependencies.entries(), getCleanDependencyName));
@@ -141,7 +141,7 @@ export async function* getRootDependencies(manifest, options) {
     const configRef = { exclude, maxDepth, parent };
     iterators = [
       ...iter.filter(customResolvers.entries(), ([, valueStr]) => isGitDependency(valueStr))
-        .map(([depName, valueStr]) => searchDeepDependencies(depName, valueStr.slice(4), configRef)),
+        .map(([depName, valueStr]) => searchDeepDependencies(depName, valueStr, configRef)),
       ...iter.map(dependencies.entries(), ([name, ver]) => searchDeepDependencies(`${name}@${ver}`, null, configRef))
     ];
   }

--- a/src/depWalker.js
+++ b/src/depWalker.js
@@ -15,7 +15,7 @@ import * as vuln from "@nodesecure/vuln";
 
 // Import Internal Dependencies
 import {
-  mergeDependencies, getCleanDependencyName, getDependenciesWarnings, addMissingVersionFlags,
+  mergeDependencies, getCleanDependencyName, getDependenciesWarnings, addMissingVersionFlags, isGitDependency,
   NPM_TOKEN
 } from "./utils/index.js";
 import { scanDirOrArchive } from "./tarball.js";
@@ -50,7 +50,7 @@ export async function* searchDeepDependencies(packageName, gitURL, options) {
       exclude, currDepth: currDepth + 1, parent: current, maxDepth
     };
 
-    const gitDependencies = iter.filter(customResolvers.entries(), ([, valueStr]) => valueStr.startsWith("git+"));
+    const gitDependencies = iter.filter(customResolvers.entries(), ([, valueStr]) => isGitDependency(valueStr));
     for (const [depName, valueStr] of gitDependencies) {
       yield* searchDeepDependencies(depName, valueStr.slice(4), config);
     }
@@ -140,7 +140,7 @@ export async function* getRootDependencies(manifest, options) {
   else {
     const configRef = { exclude, maxDepth, parent };
     iterators = [
-      ...iter.filter(customResolvers.entries(), ([, valueStr]) => valueStr.startsWith("git+"))
+      ...iter.filter(customResolvers.entries(), ([, valueStr]) => isGitDependency(valueStr))
         .map(([depName, valueStr]) => searchDeepDependencies(depName, valueStr.slice(4), configRef)),
       ...iter.map(dependencies.entries(), ([name, ver]) => searchDeepDependencies(`${name}@${ver}`, null, configRef))
     ];

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 export * from "./getTarballComposition.js";
 export * from "./isSensitiveFile.js";
+export * from "./isGitDependency.js";
 export * from "./getPackageName.js";
 export * from "./mergeDependencies.js";
 export * from "./semver.js";

--- a/src/utils/isGitDependency.js
+++ b/src/utils/isGitDependency.js
@@ -1,0 +1,20 @@
+const kGitVersionVariants = ["git:", "git+", "github:"];
+
+/**
+ * @example isGitDependency("github:NodeSecure/scanner") // => true
+ * @example isGitDependency("git+ssh://git@github.com:npm/cli#semver:^5.0") // => true
+ * @example isGitDependency(">=1.0.2 <2.1.2") // => false
+ * @example isGitDependency("http://asdf.com/asdf.tar.gz") // => false
+ * @param {string} version
+ * @returns {boolean}
+ */
+export function isGitDependency(version) {
+  for (const variant of kGitVersionVariants) {
+    if (version.startsWith(variant)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+

--- a/src/utils/mergeDependencies.js
+++ b/src/utils/mergeDependencies.js
@@ -10,7 +10,7 @@ export function mergeDependencies(manifest, types = ["dependencies"]) {
 
     for (const [name, version] of Object.entries(dep)) {
       /**
-       * Version can be file:, github:, git+, ./...
+       * Version can be file:, github:, git:, git+, ./...
        * @see https://docs.npmjs.com/cli/v7/configuring-npm/package-json#dependencies
        */
       if (/^([a-zA-Z]+:|git\+|\.\\)/.test(version)) {

--- a/test/depWalker.spec.js
+++ b/test/depWalker.spec.js
@@ -25,6 +25,10 @@ const config = JSON.parse(readFileSync(
   new URL(join(FIXTURE_PATH, "slimio.config.json"), import.meta.url)
 ));
 
+const pkgGitdeps = JSON.parse(readFileSync(
+  new URL(join(FIXTURE_PATH, "pkg.gitdeps.json"), import.meta.url)
+));
+
 function cleanupPayload(payload) {
   for (const pkg of Object.values(payload)) {
     for (const verDescriptor of Object.values(pkg.versions)) {
@@ -76,6 +80,41 @@ test("execute depWalker on @slimio/config", async(tape) => {
     "@slimio/is",
     "@iarna/toml",
     "@slimio/config"
+  ].sort());
+
+  tape.end();
+});
+
+test("execute depWalker on pkg.gitdeps", async(tape) => {
+  await setStrategy(strategies.NPM_AUDIT);
+
+  const result = await depWalker(pkgGitdeps, { verbose: false });
+  const resultAsJSON = JSON.parse(JSON.stringify(result.dependencies, null, 2));
+
+  const packages = Object.keys(resultAsJSON).sort();
+  tape.deepEqual(packages, [
+    "@nodesecure/js-x-ray",
+    "@nodesecure/sec-literal",
+    "ansi-regex",
+    "emoji-regex",
+    "estree-walker",
+    "fast-xml-parser",
+    "frequency-set",
+    "is-base64",
+    "is-fullwidth-code-point",
+    "is-minified-code",
+    "is-svg",
+    "meriyah",
+    "nanodelay",
+    "nanoevents",
+    "nanoid",
+    "pkg.gitdeps",
+    "regexp-tree",
+    "safe-regex",
+    "string-width",
+    "strip-ansi",
+    "strnum",
+    "zen-observable"
   ].sort());
 
   tape.end();

--- a/test/fixtures/depWalker/pkg.gitdeps.json
+++ b/test/fixtures/depWalker/pkg.gitdeps.json
@@ -1,0 +1,21 @@
+{
+  "name": "pkg.gitdeps",
+  "version": "0.1.0",
+  "description": "Mock package with git related dependencies versions",
+  "main": "index.js",
+  "homepage": "https://github.com/username/pkg.gitdeps#readme",
+  "devDependencies": {
+    "ava": "^2.1.0",
+    "cross-env": "^5.2.0",
+    "eslint": "^5.13.0",
+    "husky": "^2.4.0",
+    "jsdoc": "^3.6.2"
+  },
+  "dependencies": {
+    "zen-observable": "^0.8.15",
+    "nanoid": "github:ai/nanoid",
+    "js-x-ray": "git://github.com/NodeSecure/js-x-ray.git",
+    "nanodelay": "git+ssh://git@github.com:ai/nanodelay.git",
+    "nanoevents": "git+https://github.com/ai/nanoevents.git"
+  }
+}

--- a/test/tarball/scanJavascriptFile.spec.js
+++ b/test/tarball/scanJavascriptFile.spec.js
@@ -20,7 +20,7 @@ test("scanJavascriptFile (fixture one.js)", async(tape) => {
     isMinified: false,
     tryDependencies: [],
     dependencies: ["http", "mocha"],
-    filesDependencies: ["src\\foo.js", "home\\marco.js"]
+    filesDependencies: ["src\\foo.js", "home\\marco.js"].map((location) => location.replaceAll("\\", path.sep))
   });
 
   tape.end();

--- a/test/tarball/scanPackage.spec.js
+++ b/test/tarball/scanPackage.spec.js
@@ -25,9 +25,9 @@ test("scanPackage (caseone)", async(tape) => {
       "src\\other.min.js"
     ].map((location) => location.replaceAll("\\", path.sep)),
     extensions: [
+      ".txt",
       ".js",
-      ".json",
-      ".txt"
+      ".json"
     ],
     minified: [
       "src\\other.min.js"

--- a/test/tarball/scanPackage.spec.js
+++ b/test/tarball/scanPackage.spec.js
@@ -23,15 +23,15 @@ test("scanPackage (caseone)", async(tape) => {
       "package.json",
       "src\\deps.js",
       "src\\other.min.js"
-    ],
+    ].map((location) => location.replaceAll("\\", path.sep)),
     extensions: [
-      ".txt",
       ".js",
-      ".json"
+      ".json",
+      ".txt"
     ],
     minified: [
       "src\\other.min.js"
-    ]
+    ].map((location) => location.replaceAll("\\", path.sep))
   });
 
   tape.true(typeof result.directorySize === "number", "directorySize should be a number");
@@ -61,7 +61,7 @@ test("scanPackage (caseone)", async(tape) => {
     "index.js",
     "src\\deps.js",
     "src\\other.min.js"
-  ]);
+  ].map((location) => location.replaceAll("\\", path.sep)));
   tape.deepEqual(Object.keys(result.ast.dependencies["index.js"]), [
     "./src/deps.js",
     "fs",

--- a/test/utils/filterDependencyKind.spec.js
+++ b/test/utils/filterDependencyKind.spec.js
@@ -22,7 +22,7 @@ test("filterDependencyKind should be able to match all relative import path", (t
     "index.js",
     "..\\index.js",
     "..\\index.js"
-  ]);
+  ].map((location) => location.replaceAll("\\", path.sep)));
   tape.deepEqual(result.packages, []);
 
   tape.end();

--- a/test/utils/getTarballComposition.spec.js
+++ b/test/utils/getTarballComposition.spec.js
@@ -20,6 +20,7 @@ test("should return the composition of a directory", async(tape) => {
     ext: new Set(["", ".js", ".json", ".txt"]),
     size,
     files: ["one\\README", "two\\empty.txt", "two\\package.json", "two\\two-deep\\test.js"]
+      .map((location) => location.replaceAll("\\", path.sep))
   });
   tape.strictEqual(composition.files.length, 4);
   tape.match(composition.files[0], /one(\/|\\)README/);

--- a/test/utils/isGitDependency.spec.js
+++ b/test/utils/isGitDependency.spec.js
@@ -1,0 +1,32 @@
+// Import Third-party Dependencies
+import test from "tape";
+
+// Import Internal Dependencies
+import { isGitDependency } from "../../src/utils/index.js";
+
+test("isGitDependency should return true for git related package versions", (tape) => {
+  tape.true(isGitDependency("git+ssh://git@github.com:npm/cli.git#v1.0.27"));
+  tape.true(isGitDependency("git+ssh://git@github.com:npm/cli#semver:^5.0"));
+  tape.true(isGitDependency("git+https://isaacs@github.com/npm/cli.git"));
+  tape.true(isGitDependency("git://github.com/npm/cli.git#v1.0.27"));
+  tape.true(isGitDependency("github:NodeSecure/scanner"));
+
+  tape.end();
+});
+
+test("isGitDependency should return false for non git related package versions", (tape) => {
+  tape.false(isGitDependency(">=1.0.2 <2.1.2"));
+  tape.false(isGitDependency("1.0.0 - 2.9999.9999"));
+  tape.false(isGitDependency(">1.0.2 <=2.3.4"));
+  tape.false(isGitDependency("2.0.1"));
+  tape.false(isGitDependency("<1.0.0 || >=2.3.1 <2.4.5 || >=2.5.2 <3.0.0"));
+  tape.false(isGitDependency("http://asdf.com/asdf.tar.gz"));
+  tape.false(isGitDependency("~1.2"));
+  tape.false(isGitDependency("~1.2.3"));
+  tape.false(isGitDependency("2.x"));
+  tape.false(isGitDependency("3.3.x"));
+  tape.false(isGitDependency("latest"));
+  tape.false(isGitDependency("file:../dyl"));
+
+  tape.end();
+});

--- a/test/verify.spec.js
+++ b/test/verify.spec.js
@@ -21,8 +21,7 @@ function cleanupAstDependencies(dependencies) {
   return JSON.stringify(cleaned, null, 2);
 }
 
-// TODO: unskip test before PR
-test.skip("verify 'express' package", async(tape) => {
+test("verify 'express' package", async(tape) => {
   const data = await verify("express@4.17.0");
 
   tape.deepEqual(data.files, {

--- a/test/verify.spec.js
+++ b/test/verify.spec.js
@@ -21,7 +21,8 @@ function cleanupAstDependencies(dependencies) {
   return JSON.stringify(cleaned, null, 2);
 }
 
-test("verify 'express' package", async(tape) => {
+// TODO: unskip test before PR
+test.skip("verify 'express' package", async(tape) => {
   const data = await verify("express@4.17.0");
 
   tape.deepEqual(data.files, {
@@ -42,7 +43,7 @@ test("verify 'express' package", async(tape) => {
       "lib\\utils.js",
       "lib\\view.js",
       "package.json"
-    ].map((location) => path.normalize(location)),
+    ].map((location) => location.replaceAll("\\", path.sep)),
     extensions: [".md", ".js", ".json"],
     minified: []
   });


### PR DESCRIPTION
I added new `isGitDependency` utility. It will say when we deal with git-related version value.

Also, I deleted code that previously removed `git*` part from `gitUrl`.

Notes about tests: 

- Added tests for `isGitDependency` utility and `depWalker` for package with git related version links.
- `.map((location) => location.replaceAll("\\", path.sep))` – this probably should fix problem with different cross os path separator. But needs to be tested on `win` environment, can you help with this @fraxken?
- I haven't found how to fix test in `test/verify.spec.js` which is about `"verify express@4.17.0"` (https://github.com/NodeSecure/scanner/issues/17).