### PR TITLE
chore: rename analysis payload properties

### DIFF
--- a/__snapshots__/depWalker.spec.js.snapshot.js
+++ b/__snapshots__/depWalker.spec.js.snapshot.js
@@ -1,7 +1,7 @@
 exports['from pacote 1'] = [
   "id",
-  "rootDepencyName",
-  "version",
+  "rootDependencyName",
+  "scannerVersion",
   "vulnerabilityStrategy",
   "warnings",
   "dependencies"

--- a/src/depWalker.js
+++ b/src/depWalker.js
@@ -184,8 +184,8 @@ export async function depWalker(manifest, options = {}, logger = new Logger()) {
 
   const payload = {
     id: tmpLocation.slice(-6),
-    rootDepencyName: manifest.name,
-    version: packageVersion,
+    rootDependencyName: manifest.name,
+    scannerVersion: packageVersion,
     vulnerabilityStrategy,
     warnings: []
   };

--- a/types/scanner.d.ts
+++ b/types/scanner.d.ts
@@ -128,7 +128,7 @@ declare namespace Scanner {
     /** All the dependencies of the package (flattened) */
     dependencies: Dependencies;
     /** Version of the scanner used to generate the result */
-    version: string;
+    scannerVersion: string;
     /** Vulnerability strategy name (npm, snyk, node) */
     vulnerabilityStrategy: Vuln.Strategy.Kind;
   }


### PR DESCRIPTION
Following our discussion on the nsecure repository.

Here two little updates:
- `rootDepencyName`-> `rootDependencyName`
- `version` -> `scannerVersion`