### PR TITLE
Add workspaces support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ await Promise.allSettled(promises);
 See `types/api.d.ts` for a complete TypeScript definition.
 
 ```ts
-function cwd(path: string, options?: Scanner.Options): Promise<Scanner.Payload>;
+function cwd(location: string, options?: Scanner.Options): Promise<Scanner.Payload>;
 function from(packageName: string, options?: Scanner.Options): Promise<Scanner.Payload>;
-function verify(packageName: string): Promise<Scanner.VerifyPayload>;
+function verify(packageName?: string | null): Promise<Scanner.VerifyPayload>;
 ```
 
 `Options` is described with the following TypeScript interface:

--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ import * as tarball from "./src/tarball.js";
 // CONSTANTS
 const kDefaultCwdOptions = { forceRootAnalysis: true, usePackageLock: true };
 
-export async function cwd(cwd = process.cwd(), options = {}, logger = new Logger()) {
-  const finalizedOptions = Object.assign({}, kDefaultCwdOptions, options);
+export async function cwd(location = process.cwd(), options = {}, logger = new Logger()) {
+  const finalizedOptions = Object.assign({ location }, kDefaultCwdOptions, options);
 
   logger.start(ScannerLoggerEvents.manifest.read);
-  const packagePath = path.join(cwd, "package.json");
+  const packagePath = path.join(location, "package.json");
   const str = await fs.readFile(packagePath, "utf-8");
   logger.end(ScannerLoggerEvents.manifest.read);
 

--- a/src/tarball.js
+++ b/src/tarball.js
@@ -47,10 +47,10 @@ export async function scanJavascriptFile(dest, file, packageName) {
 }
 
 export async function scanDirOrArchive(name, version, options) {
-  const { ref, tmpLocation, locker } = options;
+  const { ref, location = process.cwd(), tmpLocation, locker } = options;
 
   const isNpmTarball = !(tmpLocation === null);
-  const dest = isNpmTarball ? path.join(tmpLocation, `${name}@${version}`) : process.cwd();
+  const dest = isNpmTarball ? path.join(tmpLocation, `${name}@${version}`) : location;
   const free = await locker.acquireOne();
 
   try {

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -10,6 +10,6 @@ export {
 
 declare const ScannerLoggerEvents: LoggerEvents;
 
-declare function cwd(path: string, options?: Scanner.Options, logger?: Logger): Promise<Scanner.Payload>;
+declare function cwd(location: string, options?: Scanner.Options, logger?: Logger): Promise<Scanner.Payload>;
 declare function from(packageName: string, options?: Scanner.Options, logger?: Logger): Promise<Scanner.Payload>;
-declare function verify(packageName: string): Promise<Scanner.VerifyPayload>;
+declare function verify(packageName?: string | null): Promise<Scanner.VerifyPayload>;


### PR DESCRIPTION
Add workspaces support to NodeSecure/scanner.

- I had to fix a problem with the location (it was always forced to `process.cwd()` which is a problem for API).
- Arborist already support workspaces but the `to` object was not the same
- Fixed few issues in TypeScript definitions (related to the location).

Example with [https://github.com/targos/nsecure-workspace](nsecure-workspace):
![image](https://user-images.githubusercontent.com/4438263/150647039-14e84204-24c8-44e9-a122-5bce7edc0e57.png)
