### PR TITLE
fix: add location as options of hydratePayloadDependencies

### DIFF
--- a/src/depWalker.js
+++ b/src/depWalker.js
@@ -283,7 +283,8 @@ export async function depWalker(manifest, options = {}, logger = new Logger()) {
 
   const { hydratePayloadDependencies, strategy } = await vuln.setStrategy(vulnerabilityStrategy);
   await hydratePayloadDependencies(dependencies, {
-    useStandardFormat: true
+    useStandardFormat: true,
+    path: location
   });
 
   payload.vulnerabilityStrategy = strategy;


### PR DESCRIPTION
Add missing path options (by default it will only work with process.cwd()).