### PR TITLE
feat: detect Node.js core dependency prefixed with 'node:'

### DIFF
--- a/src/utils/analyzeDependencies.js
+++ b/src/utils/analyzeDependencies.js
@@ -15,7 +15,7 @@ export function analyzeDependencies(dependencies, deps = {}) {
   const thirdPartyDependencies = dependencies
     .map((name) => (packageDeps.includes(name) ? name : getPackageName(name)))
     .filter((name) => !name.startsWith("."))
-    .filter((name) => !kNodeModules.has(name))
+    .filter((name) => !isNodeCoreModule(name))
     .filter((name) => !packageDevDeps.includes(name))
     .filter((name) => !tryDependencies.has(name));
 
@@ -24,7 +24,7 @@ export function analyzeDependencies(dependencies, deps = {}) {
     thirdPartyDependencies
   );
   const missingDependencies = [...new Set(difference(thirdPartyDependencies, packageDeps))];
-  const nodeDependencies = dependencies.filter((name) => kNodeModules.has(name));
+  const nodeDependencies = dependencies.filter((name) => isNodeCoreModule(name));
 
   return {
     nodeDependencies,
@@ -37,4 +37,15 @@ export function analyzeDependencies(dependencies, deps = {}) {
       hasMissingOrUnusedDependency: unusedDependencies.length > 0 || missingDependencies.length > 0
     }
   };
+}
+
+/**
+ * @param {!string} moduleName
+ * @returns {boolean}
+ */
+function isNodeCoreModule(moduleName) {
+  const cleanModuleName = moduleName.startsWith("node:") ? moduleName.slice(5) : moduleName;
+
+  // Note: We need to also check moduleName because builtins package only return true for 'node:test'.
+  return kNodeModules.has(cleanModuleName) || kNodeModules.has(moduleName);
 }

--- a/test/utils/analyzeDependencies.spec.js
+++ b/test/utils/analyzeDependencies.spec.js
@@ -24,6 +24,27 @@ test("analyzeDependencies should detect Node.js dependencies and also flag hasEx
   tape.end();
 });
 
+test("analyzeDependencies should detect prefixed (namespaced 'node:') core dependencies", (tape) => {
+  const packageDeps = ["node:foobar"];
+  const packageDevDeps = [];
+
+  const result = analyzeDependencies([
+    "node:fs",
+    "node:test",
+    "node:foobar"
+  ], { packageDeps, packageDevDeps, tryDependencies: new Set() });
+
+  tape.deepEqual(result, {
+    nodeDependencies: ["node:fs", "node:test"],
+    thirdPartyDependencies: ["node:foobar"],
+    unusedDependencies: [],
+    missingDependencies: [],
+    flags: { hasExternalCapacity: false, hasMissingOrUnusedDependency: false }
+  });
+
+  tape.end();
+});
+
 test("analyzeDependencies should be capable of detecting unused dependency 'koa'", (tape) => {
   const packageDeps = ["koa", "kleur"];
   const packageDevDeps = ["mocha"];


### PR DESCRIPTION
This PR add detection for Node.js core dependency prefixed with `node:`, example:

```js
import fs from "node:fs";
import test from "node:test";
```