### PR TITLE
feat: add experimental support for Node.js subpath imports

### DIFF
--- a/__snapshots__/depWalker.spec.js.snapshot.js
+++ b/__snapshots__/depWalker.spec.js.snapshot.js
@@ -26,7 +26,8 @@ exports['walk @slimio/is 1'] = {
           "unused": [],
           "missing": [],
           "required_nodejs": [],
-          "required_thirdparty": []
+          "required_thirdparty": [],
+          "required_subpath": {}
         },
         "license": {
           "uniqueLicenseIds": [

--- a/__snapshots__/verify.spec.js.snapshot.js
+++ b/__snapshots__/verify.spec.js.snapshot.js
@@ -543,6 +543,218 @@ exports['verify express@4.17.0 1'] = {
       }
     }
   },
+  "lib\\response.js": {
+    "safe-buffer": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 15,
+          "column": 13
+        },
+        "end": {
+          "line": 15,
+          "column": 35
+        }
+      }
+    },
+    "content-disposition": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 16,
+          "column": 25
+        },
+        "end": {
+          "line": 16,
+          "column": 55
+        }
+      }
+    },
+    "depd": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 17,
+          "column": 16
+        },
+        "end": {
+          "line": 17,
+          "column": 31
+        }
+      }
+    },
+    "encodeurl": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 18,
+          "column": 16
+        },
+        "end": {
+          "line": 18,
+          "column": 36
+        }
+      }
+    },
+    "escape-html": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 19,
+          "column": 17
+        },
+        "end": {
+          "line": 19,
+          "column": 39
+        }
+      }
+    },
+    "http": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 20,
+          "column": 11
+        },
+        "end": {
+          "line": 20,
+          "column": 26
+        }
+      }
+    },
+    "./utils": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 29,
+          "column": 17
+        },
+        "end": {
+          "line": 29,
+          "column": 35
+        }
+      }
+    },
+    "on-finished": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 22,
+          "column": 17
+        },
+        "end": {
+          "line": 22,
+          "column": 39
+        }
+      }
+    },
+    "path": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 23,
+          "column": 11
+        },
+        "end": {
+          "line": 23,
+          "column": 26
+        }
+      }
+    },
+    "statuses": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 24,
+          "column": 15
+        },
+        "end": {
+          "line": 24,
+          "column": 34
+        }
+      }
+    },
+    "utils-merge": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 25,
+          "column": 12
+        },
+        "end": {
+          "line": 25,
+          "column": 34
+        }
+      }
+    },
+    "cookie-signature": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 26,
+          "column": 11
+        },
+        "end": {
+          "line": 26,
+          "column": 38
+        }
+      }
+    },
+    "cookie": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 30,
+          "column": 13
+        },
+        "end": {
+          "line": 30,
+          "column": 30
+        }
+      }
+    },
+    "send": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 31,
+          "column": 11
+        },
+        "end": {
+          "line": 31,
+          "column": 26
+        }
+      }
+    },
+    "vary": {
+      "unsafe": false,
+      "inTry": false,
+      "location": {
+        "start": {
+          "line": 35,
+          "column": 11
+        },
+        "end": {
+          "line": 35,
+          "column": 26
+        }
+      }
+    }
+  },
   "lib\\router\\index.js": {
     "./route": {
       "unsafe": false,

--- a/src/class/dependency.class.js
+++ b/src/class/dependency.class.js
@@ -75,7 +75,8 @@ export default class Dependency {
             missing: [],
             required_files: [],
             required_nodejs: [],
-            required_thirdparty: []
+            required_thirdparty: [],
+            required_subpath: []
           },
           license: "unkown license",
           gitUrl: this.gitUrl

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -33,11 +33,11 @@ export async function read(location) {
   return JSON.parse(packageStr);
 }
 
-// TODO: PR @npm/types to fix dependencies typo
 export async function readAnalyze(location) {
   const {
     description = "", author = {}, scripts = {},
-    dependencies = {}, devDependencies = {}, gypfile = false
+    dependencies = {}, devDependencies = {}, gypfile = false,
+    imports = {}
   } = await read(location);
 
   const packageDeps = Object.keys(dependencies);
@@ -52,6 +52,7 @@ export async function readAnalyze(location) {
       .some((value) => kUnsafeNpmScripts.has(value.toLowerCase())),
     packageDeps,
     packageDevDeps,
+    nodejs: { imports },
     hasNativeElements: hasNativePackage || gypfile
   };
 }

--- a/src/tarball.js
+++ b/src/tarball.js
@@ -65,7 +65,9 @@ export async function scanDirOrArchive(name, version, options) {
     }
 
     // Read the package.json at the root of the directory or archive.
-    const { packageDeps, packageDevDeps, author, description, hasScript, hasNativeElements } = await manifest.readAnalyze(dest);
+    const {
+      packageDeps, packageDevDeps, author, description, hasScript, hasNativeElements, nodejs
+    } = await manifest.readAnalyze(dest);
     ref.author = author;
     ref.description = description;
 
@@ -97,10 +99,11 @@ export async function scanDirOrArchive(name, version, options) {
     const minifiedFiles = fileAnalysisResults.filter((row) => row.isMinified).flatMap((row) => row.file);
 
     const {
-      nodeDependencies, thirdPartyDependencies, missingDependencies, unusedDependencies, flags
-    } = analyzeDependencies(dependencies, { packageDeps, packageDevDeps, tryDependencies });
+      nodeDependencies, thirdPartyDependencies, subpathImportsDependencies, missingDependencies, unusedDependencies, flags
+    } = analyzeDependencies(dependencies, { packageDeps, packageDevDeps, tryDependencies, nodeImports: nodejs.imports });
 
     ref.composition.required_thirdparty = thirdPartyDependencies;
+    ref.composition.required_subpath = Object.fromEntries(subpathImportsDependencies);
     ref.composition.unused.push(...unusedDependencies);
     ref.composition.missing.push(...missingDependencies);
     ref.composition.required_files = filesDependencies;

--- a/test/manifest.spec.js
+++ b/test/manifest.spec.js
@@ -21,6 +21,7 @@ test("manifest.readAnalyze with a fake empty package.json (so all default values
   tape.false(manifestResult.hasScript);
   tape.deepEqual(manifestResult.author, {});
   tape.strictEqual(manifestResult.description, "");
+  tape.deepEqual(manifestResult.nodejs, { imports: {} });
   tape.true(readFile.calledWith(path.join(process.cwd(), "package.json"), "utf-8"));
   tape.true(readFile.calledOnce);
 
@@ -40,6 +41,11 @@ test("manifest.readAnalyze with a fake but consistent data", async(tape) => {
     devDependencies: {
       mocha: ">=2.5.0"
     },
+    imports: {
+      "#dep": {
+        node: "kleur"
+      }
+    },
     gypfile: true
   }));
   tape.teardown(() => readFile.restore());
@@ -48,6 +54,11 @@ test("manifest.readAnalyze with a fake but consistent data", async(tape) => {
 
   tape.deepEqual(manifestResult.packageDeps, ["@slimio/is"]);
   tape.deepEqual(manifestResult.packageDevDeps, ["mocha"]);
+  tape.deepEqual(manifestResult.nodejs.imports, {
+    "#dep": {
+      node: "kleur"
+    }
+  });
   tape.true(manifestResult.hasNativeElements);
   tape.true(manifestResult.hasScript);
   tape.deepEqual(manifestResult.author, {

--- a/test/verify.spec.js
+++ b/test/verify.spec.js
@@ -79,7 +79,7 @@ test("verify 'express' package", async(tape) => {
 
   tape.true(data.ast.warnings.length === 2);
   const warningName = data.ast.warnings.map((row) => row.kind);
-  tape.deepEqual(warningName, ["parsing-error", "unsafe-import"]);
+  tape.deepEqual(warningName, ["unsafe-import"]);
 
   snapshot.core({
     what: data.ast.dependencies,

--- a/types/scanner.d.ts
+++ b/types/scanner.d.ts
@@ -58,6 +58,7 @@ declare namespace Scanner {
       required_files: string[];
       required_thirdparty: string[];
       required_nodejs: string[];
+      required_subpath: string[];
       unused: string[];
       missing: string[];
     };


### PR DESCRIPTION
Add initial support of Node.js subpath imports (see https://nodejs.org/api/packages.html#subpath-imports).

```js
const foo = require("#dep");
```

And in package.json:

```json
{
  "imports": {
    "#dep": {
      "node": "kleur"
    }
  }
}
```

So in the code foo is equal to `kleur` dependency.
