### PR TITLE
fix: make tests to pass on node >= 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6503,9 +6503,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
-      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
+      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q==",
       "engines": {
         "node": ">=12.18"
       }
@@ -11599,9 +11599,9 @@
       }
     },
     "undici": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
-      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
+      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q=="
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/src/utils/isGitDependency.js
+++ b/src/utils/isGitDependency.js
@@ -7,5 +7,5 @@
  * @returns {boolean}
  */
 export function isGitDependency(version) {
-  return /^git(\:|\+|hub:)/.test(version);
+  return /^git(:|\+|hub:)/.test(version);
 }

--- a/test/utils/analyzeDependencies.spec.js
+++ b/test/utils/analyzeDependencies.spec.js
@@ -26,21 +26,21 @@ test("analyzeDependencies should detect Node.js dependencies and also flag hasEx
 });
 
 test("analyzeDependencies should detect prefixed (namespaced 'node:') core dependencies", (tape) => {
-  const packageDeps = ["node:foobar"];
+  const packageDeps = ["node:foo"];
   const packageDevDeps = [];
 
   const result = analyzeDependencies([
     "node:fs",
-    "node:test",
-    "node:foobar"
+    "node:foo",
+    "node:bar"
   ], { packageDeps, packageDevDeps, tryDependencies: new Set() });
 
   tape.deepEqual(result, {
     nodeDependencies: ["node:fs"],
-    thirdPartyDependencies: ["node:test", "node:foobar"],
+    thirdPartyDependencies: ["node:foo", "node:bar"],
     subpathImportsDependencies: [],
     unusedDependencies: [],
-    missingDependencies: ["node:test"],
+    missingDependencies: ["node:bar"],
     flags: { hasExternalCapacity: false, hasMissingOrUnusedDependency: true }
   });
 


### PR DESCRIPTION
This PR fixes 3 things:
- fix 1 vulnerability bumping undici from 5.5.1 to 5.8.0 (npm audit fix)
- fix useless escaped character in the `isGitDependency` regex (linter was KO)
- remove `node:test` as there is now the [Test runner](https://nodejs.org/api/test.html), also added in [builtins library](https://github.com/juliangruber/builtins/commit/0770b382f2bb888dcd5e2d786154d0d985be3daa) so tests was down on Node >= 18