### PR TITLE
feat: add detection for npm: alias resolver

### DIFF
--- a/__snapshots__/depWalker.spec.js.snapshot.js
+++ b/__snapshots__/depWalker.spec.js.snapshot.js
@@ -40,6 +40,7 @@ exports['walk @slimio/is 1'] = {
           "minified": [],
           "unused": [],
           "missing": [],
+          "alias": {},
           "required_nodejs": [],
           "required_thirdparty": [],
           "required_subpath": {}

--- a/src/class/dependency.class.js
+++ b/src/class/dependency.class.js
@@ -10,6 +10,7 @@ export default class Dependency {
     this.version = version;
     this.dev = false;
     this.existOnRemoteRegistry = true;
+    this.alias = {};
 
     if (parent !== null) {
       parent.dependencyCount++;
@@ -78,6 +79,7 @@ export default class Dependency {
             minified: [],
             unused: [],
             missing: [],
+            alias: this.alias,
             required_files: [],
             required_nodejs: [],
             required_thirdparty: [],

--- a/src/depWalker.js
+++ b/src/depWalker.js
@@ -37,9 +37,11 @@ export async function* searchDeepDependencies(packageName, gitURL, options) {
     registry,
     cache: `${os.homedir()}/.npm`
   });
-  const { dependencies, customResolvers } = mergeDependencies(pkg);
+  const { dependencies, customResolvers, alias } = mergeDependencies(pkg);
 
   const current = new Dependency(name, version, parent);
+  current.alias = Object.fromEntries(alias);
+
   if (gitURL !== null) {
     current.isGit(gitURL);
     try {
@@ -100,8 +102,9 @@ export async function* deepReadEdges(currentPackageName, options) {
       registry,
       cache: `${os.homedir()}/.npm`
     });
-    const { customResolvers } = mergeDependencies(pkg);
+    const { customResolvers, alias } = mergeDependencies(pkg);
 
+    current.alias = Object.fromEntries(alias);
     current.addFlag("hasValidIntegrity", _integrity === integrity);
     current.addFlag("isDeprecated");
     current.addFlag("hasCustomResolver", customResolvers.size > 0);
@@ -137,8 +140,9 @@ export async function* getRootDependencies(manifest, options) {
     registry
   } = options;
 
-  const { dependencies, customResolvers } = mergeDependencies(manifest, void 0);
+  const { dependencies, customResolvers, alias } = mergeDependencies(manifest, void 0);
   const parent = new Dependency(manifest.name, manifest.version);
+  parent.alias = Object.fromEntries(alias);
 
   try {
     await pacote.manifest(`${manifest.name}@${manifest.version}`, {

--- a/src/utils/mergeDependencies.js
+++ b/src/utils/mergeDependencies.js
@@ -1,6 +1,7 @@
 export function mergeDependencies(manifest, types = ["dependencies"]) {
   const dependencies = new Map();
   const customResolvers = new Map();
+  const alias = new Map();
 
   for (const fieldName of types) {
     if (!Reflect.has(manifest, fieldName)) {
@@ -15,12 +16,15 @@ export function mergeDependencies(manifest, types = ["dependencies"]) {
        */
       if (/^([a-zA-Z]+:|git\+|\.\\)/.test(version)) {
         customResolvers.set(name, version);
-        continue;
+        if (!version.startsWith("npm:")) {
+          continue;
+        }
+        alias.set(name, version.slice(4));
       }
 
       dependencies.set(name, version);
     }
   }
 
-  return { dependencies, customResolvers };
+  return { dependencies, customResolvers, alias };
 }

--- a/test/class/dependency.spec.js
+++ b/test/class/dependency.spec.js
@@ -17,8 +17,9 @@ test("Dependency class should act as expected by assertions", (tape) => {
   tape.strictEqual(dep.dependencyCount, 0);
   tape.strictEqual(dep.existOnRemoteRegistry, true);
   tape.deepEqual(dep.warnings, []);
+  tape.deepEqual(dep.alias, {});
   tape.strictEqual(dep.gitUrl, null);
-  tape.strictEqual(Reflect.ownKeys(dep).length, 7);
+  tape.strictEqual(Reflect.ownKeys(dep).length, 8);
 
   const flagOne = dep.flags;
   const flagTwo = dep.flags;

--- a/test/utils/mergeDependencies.spec.js
+++ b/test/utils/mergeDependencies.spec.js
@@ -74,3 +74,19 @@ test("should return no dependencies/customResolvers for three.json", (tape) => {
 
   tape.end();
 });
+
+test("should detect NPM alias using custom resolvers npm: (but still count it as normal dependency)", (tape) => {
+  const result = mergeDependencies({
+    dependencies: {
+      test: "npm:fastify@^4.7.0"
+    }
+  }, ["dependencies", "devDependencies"]);
+  tape.true(is.plainObject(result), "result value of mergeDependencies must be a plainObject.");
+
+  tape.strictEqual(result.dependencies.size, 1);
+  tape.strictEqual(result.customResolvers.size, 1);
+  tape.true(result.alias.has("test"));
+  tape.strictEqual(result.alias.get("test"), "fastify@^4.7.0");
+
+  tape.end();
+});

--- a/types/scanner.d.ts
+++ b/types/scanner.d.ts
@@ -69,6 +69,7 @@ declare namespace Scanner {
       files: string[];
       /** Minified files (foo.min.js etc..) */
       minified: string[];
+      alias: Record<string, string>;
       required_files: string[];
       required_thirdparty: string[];
       required_nodejs: string[];


### PR DESCRIPTION
Related to #44 

`npm:` resolver was actually ignored with an analysis that were not using Arborist (so it was only working as expected using `cwd`).

Now **mergeDependencies** function still add the dependency as "normal" dependency (since pacote is capable to resolve it anyway). However we add a new `alias` payload to be capable to tell that **test** is in realy pointing to **fastify**.