### PR TITLE
fix(package): add missing i18n folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "src",
+    "i18n",
     "types",
     "index.js",
     "index.d.ts"


### PR DESCRIPTION
This should fixes this error:
> /node_modules/@nodesecure/scanner/i18n directory does not exist on this project.

You can see the error [here](https://github.com/NodeSecure/cli/actions/runs/6218558024/job/16875187462?pr=236#step:8:236)