### PR TITLE
chore: make tests to pass

### DIFF
--- a/test/depWalker.spec.js
+++ b/test/depWalker.spec.js
@@ -109,6 +109,7 @@ test("execute depWalker on pkg.gitdeps", async() => {
     "safe-regex",
     "string-width",
     "strip-ansi",
+    "ts-pattern",
     "zen-observable"
   ].sort());
 });

--- a/test/fixtures/depWalker/slimio.is-result.json
+++ b/test/fixtures/depWalker/slimio.is-result.json
@@ -100,7 +100,7 @@
       "lastUpdateAt": "2023-01-23T02:15:37.203Z",
       "lastVersion": "2.0.0",
       "hasManyPublishers": true,
-      "hasReceivedUpdateInOneYear": true,
+      "hasReceivedUpdateInOneYear": false,
       "homepage": "https://github.com/SlimIO/is#readme",
       "author": {
         "name": "SlimIO"


### PR DESCRIPTION
`ts-pattern` is because it has been added in js-x-ray [in this PR](https://github.com/NodeSecure/js-x-ray/pull/239).
The second one is because `@slimio/is` has not been updated in the last year.
