### PR TITLE
feat(scanner/depWalker): add missing metadata when manifest does not exists on remote registry

### DIFF
--- a/workspaces/scanner/src/utils/getLinks.ts
+++ b/workspaces/scanner/src/utils/getLinks.ts
@@ -1,5 +1,5 @@
 // Import Third-party Dependencies
-import type { PackumentVersion } from "@nodesecure/npm-types";
+import type { PackageJSON, PackumentVersion } from "@nodesecure/npm-types";
 
 // CONSTANTS
 const kVCSHosts = new Set(["github.com", "gitlab.com"]);
@@ -38,6 +38,21 @@ export function getLinks(
 
   return {
     npm: `https://www.npmjs.com/package/${packumentVersion.name}/v/${packumentVersion.version}`,
+    homepage,
+    repository:
+      getVCSRepositoryURL(homepage) ??
+      getVCSRepositoryURL(repositoryUrl)
+  };
+}
+
+export function getManifestLinks(manifest: PackageJSON) {
+  const homepage = manifest.homepage ?? null;
+  const repositoryUrl = typeof manifest.repository === "string" ?
+    manifest.repository :
+    manifest.repository?.url ?? null;
+
+  return {
+    npm: null,
     homepage,
     repository:
       getVCSRepositoryURL(homepage) ??

--- a/workspaces/scanner/src/utils/index.ts
+++ b/workspaces/scanner/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from "./addMissingVersionFlags.js";
 export * from "./getLinks.js";
 export * from "./urlToString.js";
 export * from "./getUsedDeps.js";
+export * from "./manifestAuthor.js";
 
 export const NPM_TOKEN = typeof process.env.NODE_SECURE_TOKEN === "string" ?
   { token: process.env.NODE_SECURE_TOKEN } :

--- a/workspaces/scanner/src/utils/manifestAuthor.ts
+++ b/workspaces/scanner/src/utils/manifestAuthor.ts
@@ -1,0 +1,21 @@
+// Import Third-party Dependencies
+import type { Contact } from "@nodesecure/npm-types";
+
+export function manifestAuthor(author: string | Contact | undefined): Contact | null {
+  if (author === void 0) {
+    return null;
+  }
+
+  if (typeof author === "string") {
+    if (author.trim() === "") {
+      return null;
+    }
+
+    const authorRegexp = /^([^<(]+?)?[ \t]*(?:<([^>(]+?)>)?[ \t]*(?:\(([^)]+?)\)|$)/g;
+    const [_, name, email, url] = authorRegexp.exec(author) ?? [];
+
+    return { name, email, url };
+  }
+
+  return author;
+}

--- a/workspaces/scanner/test/fixtures/depWalker/non-npm-package/package.json
+++ b/workspaces/scanner/test/fixtures/depWalker/non-npm-package/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "non-npm-package",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "description": "",
+  "dependencies": {
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NodeSecure/non-npm-package.git"
+  },
+  "author": "NodeSecure",
+  "homepage": "https://nodesecure.com"
+}

--- a/workspaces/scanner/test/utils/getLinks.spec.ts
+++ b/workspaces/scanner/test/utils/getLinks.spec.ts
@@ -1,0 +1,97 @@
+// Import Node.js Dependencies
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// Import Third-party Dependencies
+import { type PackumentVersion } from "@nodesecure/npm-types";
+
+// Import Internal Dependencies
+import * as utils from "../../src/utils/index.js";
+
+describe("utils.getLinks", () => {
+  it("should return all links", () => {
+    assert.deepStrictEqual(utils.getLinks({
+      homepage: "https://github.com/foo/bar",
+      repository: "git@github.com:foo/bar.git",
+      name: "foo",
+      version: "1.0.0"
+    } as any as PackumentVersion), {
+      npm: "https://www.npmjs.com/package/foo/v/1.0.0",
+      homepage: "https://github.com/foo/bar",
+      repository: "https://github.com/foo/bar"
+    });
+  });
+
+  it("homepage should be null but repository should be parsed", () => {
+    assert.deepStrictEqual(utils.getLinks({
+      homepage: null,
+      repository: "https://github.com/foo/bar.git",
+      name: "foo",
+      version: "1.0.0"
+    } as any), {
+      npm: "https://www.npmjs.com/package/foo/v/1.0.0",
+      homepage: null,
+      repository: "https://github.com/foo/bar"
+    });
+  });
+
+  it("should return repository.url", () => {
+    assert.deepStrictEqual(utils.getLinks({
+      name: "foo",
+      version: "1.0.0",
+      homepage: "https://github.com/foo/bar",
+      repository: {
+        type: "git",
+        url: "github.com/foo/bar"
+      }
+    } as any), {
+      npm: "https://www.npmjs.com/package/foo/v/1.0.0",
+      homepage: "https://github.com/foo/bar",
+      repository: "https://github.com/foo/bar"
+    });
+  });
+});
+
+describe("utils.getManifestLinks", () => {
+  it("should return homepage and repository", () => {
+    assert.deepStrictEqual(utils.getManifestLinks({
+      name: "@foo/bar",
+      version: "1.0.0",
+      homepage: "https://github.com/foo/bar",
+      repository: "https://github.com/foo/bar"
+    }), {
+      npm: null,
+      homepage: "https://github.com/foo/bar",
+      repository: "https://github.com/foo/bar"
+    });
+  });
+
+  it("should return repository only", () => {
+    assert.deepStrictEqual(utils.getManifestLinks({
+      name: "@foo/bar",
+      version: "1.0.0",
+      homepage: void 0,
+      repository: "https://github.com/foo/bar"
+    }), {
+      npm: null,
+      homepage: null,
+      repository: "https://github.com/foo/bar"
+    });
+  });
+
+  it("should return repository.url", () => {
+    assert.deepStrictEqual(utils.getManifestLinks({
+      name: "@foo/bar",
+      version: "1.0.0",
+      homepage: void 0,
+      repository: {
+        type: "git",
+        url: "https://github.com/foo/bar"
+      }
+    }), {
+      npm: null,
+      homepage: null,
+      repository: "https://github.com/foo/bar"
+    });
+  });
+});

--- a/workspaces/scanner/test/utils/manifestAuthor.spec.ts
+++ b/workspaces/scanner/test/utils/manifestAuthor.spec.ts
@@ -1,0 +1,50 @@
+// Import Node.js Dependencies
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// Import Internal Dependencies
+import * as utils from "../../src/utils/index.js";
+
+describe("utils.manifestAuthor", () => {
+  it("should return null when given undefined", () => {
+    assert.strictEqual(utils.manifestAuthor(undefined), null);
+  });
+
+  it("should return null when given empty string", () => {
+    assert.strictEqual(utils.manifestAuthor(""), null);
+  });
+
+  it("should return author object with only name", () => {
+    assert.deepStrictEqual(utils.manifestAuthor("John Doe"), {
+      name: "John Doe",
+      email: void 0,
+      url: void 0
+    });
+  });
+
+  it("should return author object with name and email", () => {
+    assert.deepStrictEqual(utils.manifestAuthor("John Doe <john@doe.com>"), {
+      name: "John Doe",
+      email: "john@doe.com",
+      url: void 0
+    });
+  });
+
+  it("should return author object with name, email and url", () => {
+    assert.deepStrictEqual(utils.manifestAuthor("John Doe <john@doe.com> (john.com)"), {
+      name: "John Doe",
+      email: "john@doe.com",
+      url: "john.com"
+    });
+  });
+
+  it("should return given author object", () => {
+    const author = {
+      name: "John Doe",
+      email: "john@doe.com",
+      url: "john.com"
+    };
+
+    assert.deepStrictEqual(utils.manifestAuthor(author), author);
+  });
+});


### PR DESCRIPTION
…exists on remote registry

This PR is related to https://github.com/NodeSecure/cli/issues/471

When manifest (root package.json) is not on NPM, we miss some data we could extract from manifest. I've added `author`, `homepage` and `repository` in addition to `links`.