### PR TITLE
Refacto/#380 extract licenses apis to support manifestmanager input

### DIFF
--- a/workspaces/conformance/src/extract.ts
+++ b/workspaces/conformance/src/extract.ts
@@ -22,49 +22,54 @@ const kInvalidLicense = "invalid license";
 export type ManifestManagerLike = string | ManifestManager;
 
 function getManifestManagerAndDirAsync(
-  input: ManifestManagerLike,
-  fsEngine: typeof fs
-): Promise<{ mama: ManifestManager; dir: string }> {
+  input: ManifestManagerLike
+): Promise<{ mama: ManifestManager; dir: string; }> {
   if (typeof input === "string") {
-    return ManifestManager.fromPackageJSON(input).then(mama => ({
-      mama,
-      dir: input
-    }));
-  } else if (input instanceof ManifestManager) {
+    return ManifestManager.fromPackageJSON(input).then((mama) => {
+      return {
+        mama,
+        dir: input
+      };
+    });
+  }
+  else if (input instanceof ManifestManager) {
     const manifestPath = input.manifestLocation;
     if (!manifestPath) {
       throw new Error("ManifestManager instance must have a manifestLocation property set.");
     }
     const dir = path.dirname(manifestPath);
+
     return Promise.resolve({ mama: input, dir });
-  } else {
-    throw new TypeError("Input must be a string or a ManifestManager instance");
   }
+  throw new TypeError("Input must be a string or a ManifestManager instance");
 }
 
 function getManifestManagerAndDirSync(
   input: ManifestManagerLike,
   fsEngine: typeof fsSync
-): { mama: ManifestManager; dir: string } {
+): { mama: ManifestManager; dir: string; } {
   if (typeof input === "string") {
     const packageStr = fsEngine.readFileSync(
       path.join(input, kManifestFileName), "utf-8"
     );
+
     const packageJSON = JSON.parse(packageStr);
+
     return {
       mama: new ManifestManager(packageJSON, path.join(input, kManifestFileName)),
       dir: input
     };
-  } else if (input instanceof ManifestManager) {
+  }
+  else if (input instanceof ManifestManager) {
     const manifestPath = input.manifestLocation;
     if (!manifestPath) {
       throw new Error("ManifestManager instance must have a manifestLocation property set.");
     }
     const dir = path.dirname(manifestPath);
+
     return { mama: input, dir };
-  } else {
-    throw new TypeError("Input must be a string or a ManifestManager instance");
   }
+  throw new TypeError("Input must be a string or a ManifestManager instance");
 }
 
 export interface ExtractAsyncOptions {
@@ -76,7 +81,7 @@ export async function extractLicenses(
   options: ExtractAsyncOptions = {}
 ): Promise<SpdxExtractedResult> {
   const { fsEngine = fs } = options;
-  const { mama, dir } = await getManifestManagerAndDirAsync(input, fsEngine);
+  const { mama, dir } = await getManifestManagerAndDirAsync(input);
 
   const licenseData = new LicenseResult()
     .addLicenseID(

--- a/workspaces/conformance/test/extract.spec.ts
+++ b/workspaces/conformance/test/extract.spec.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import assert from "node:assert";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
 
 // Import Internal Dependencies
 import {
@@ -10,6 +12,7 @@ import {
   extractLicensesSync
 } from "../src/index.js";
 import expectedParsedLicense from "./fixtures/parseLicense.snap.js";
+import { ManifestManager } from "@nodesecure/mama";
 
 // CONSTANTS
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -28,6 +31,17 @@ describe("extractLicenses", () => {
 
     assert.deepStrictEqual(result.uniqueLicenseIds, ["Artistic-2.0"]);
   });
+
+  it("should work with a ManifestManager instance (async)", async() => {
+    const projectPath = path.join(kFixturePath, "project1");
+    const manifestPath = path.join(projectPath, "package.json");
+    const packageStr = await fs.readFile(manifestPath, "utf-8");
+    const packageJSON = JSON.parse(packageStr);
+    const mama = new ManifestManager(packageJSON, manifestPath);
+    const result = await extractLicenses(mama);
+    assert.deepStrictEqual(result.uniqueLicenseIds, ["ISC", "MIT"]);
+    assert.deepStrictEqual(result, expectedParsedLicense);
+  });
 });
 
 describe("extractLicensesSync", () => {
@@ -42,5 +56,16 @@ describe("extractLicensesSync", () => {
     const result = extractLicensesSync(path.join(kFixturePath, "project2"));
 
     assert.deepStrictEqual(result.uniqueLicenseIds, ["Artistic-2.0"]);
+  });
+
+  it("should work with a ManifestManager instance (sync)", () => {
+    const projectPath = path.join(kFixturePath, "project1");
+    const manifestPath = path.join(projectPath, "package.json");
+    const packageStr = fsSync.readFileSync(manifestPath, "utf-8");
+    const packageJSON = JSON.parse(packageStr);
+    const mama = new ManifestManager(packageJSON, manifestPath);
+    const result = extractLicensesSync(mama);
+    assert.deepStrictEqual(result.uniqueLicenseIds, ["ISC", "MIT"]);
+    assert.deepStrictEqual(result, expectedParsedLicense);
   });
 });

--- a/workspaces/mama/src/ManifestManager.class.ts
+++ b/workspaces/mama/src/ManifestManager.class.ts
@@ -65,6 +65,7 @@ export class ManifestManager<
     ManifestManagerDocument,
     NonOptionalPackageJSONProperties
   >;
+  public manifestLocation?: string;
 
   public flags = Object.seal({
     hasUnsafeScripts: false,
@@ -72,12 +73,14 @@ export class ManifestManager<
   });
 
   constructor(
-    document: ManifestManagerDocument
+    document: ManifestManagerDocument,
+    manifestLocation?: string
   ) {
     this.document = Object.assign(
       { ...ManifestManager.Default },
       structuredClone(document)
     );
+    this.manifestLocation = manifestLocation;
 
     this.flags.isNative = [
       ...this.dependencies,
@@ -211,7 +214,8 @@ export class ManifestManager<
       ) as PackageJSON | WorkspacesPackageJSON;
 
       return new ManifestManager(
-        packageJSON
+        packageJSON,
+        packageLocation
       );
     }
     catch (cause) {

--- a/workspaces/mama/test/ManifestManager.spec.ts
+++ b/workspaces/mama/test/ManifestManager.spec.ts
@@ -79,6 +79,10 @@ describe("ManifestManager", () => {
         mama.spec,
         `${kMinimalPackageJSON.name}@${kMinimalPackageJSON.version}`
       );
+      assert.strictEqual(
+        mama.manifestLocation,
+        location
+      );
     });
 
     test("Given an invalid JSON, it should throw a custom Error with the parsing error as a cause", async(t: TestContext) => {
@@ -135,6 +139,12 @@ describe("ManifestManager", () => {
           ...ManifestManager.Default
         }
       );
+    });
+
+    it("Should store manifestLocation if provided", () => {
+      const location = "/tmp/fake/path/package.json";
+      const mama = new ManifestManager(kMinimalPackageJSON, location);
+      assert.strictEqual(mama.manifestLocation, location);
     });
   });
 


### PR DESCRIPTION
Voici la PR pour l'issue 380  j'èspère avoir bien compris ce qui était attendu 😅  
Au départ j'avais implémenté directement la logic de gestion des entrées dans extractLicenses et extractLicensesSynch puis je me dis on ne sais jamais ...  comme je découvre le projet  j'ai créé dans le même fichier des utilitaires pour séparer un peu les choses. j'espère que c'est pertinent par rapport à l'utilisation du scanner.  Cette semaine je vais faire de la lecture pour apprendre plus sur SPDX  ✊

## Refactor: Supporte l’entrée ManifestManager dans extractLicenses & extractLicensesSync

### Changements principaux

- **Ajout d’une propriété `manifestLocation`** à la classe `ManifestManager` (dans le workspace `mama`), pour mémoriser le chemin du manifeste lors de l’instanciation.
- **Refactorisation des fonctions `extractLicenses` et `extractLicensesSync`** (dans le workspace `conformance`) :
  - Acceptent désormais un chemin ou une instance de `ManifestManager`.
  - Utilisation d’une fonction utilitaire interne pour centraliser la logique de gestion de l’entrée.
- **Ajout de tests** pour garantir le bon fonctionnement avec les deux types d’entrée (string et instance).

---

### Checklist

- [x] Refactor des fonctions concernées
- [x] Ajout de la propriété `manifestLocation` à `ManifestManager`
- [x] Couverture de tests pour les deux types d’entrée