### PR TITLE
feat(extractor): Implement eventTarget for browser compatibility

### DIFF
--- a/.changeset/colorless-green-ideas.md
+++ b/.changeset/colorless-green-ideas.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/scanner": minor
+---
+
+feat(extractor): Extends eventTarget instead of eventEmitter for browser compatibility


### PR DESCRIPTION
Keep "on" and "emit" methods to not introduce breaking changes.