### PR TITLE
fix: event listener error handling

### DIFF
--- a/.changeset/fluffy-puffin-flock.md
+++ b/.changeset/fluffy-puffin-flock.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/scanner": patch
+---
+
+fix(extractor): improve error handling for event listener

--- a/workspaces/scanner/test/extractors/payload.spec.ts
+++ b/workspaces/scanner/test/extractors/payload.spec.ts
@@ -281,6 +281,31 @@ describe("Extractors.Payload events", () => {
     assert.deepEqual(packumentEvents, expectedPackumentEvents);
     assert.deepEqual(manifestEvents, expectedManifestEvents);
   });
+
+  it("should emit error when extraction listener goes wrong", () => {
+    const extractor = new Extractors.Payload(
+      expressNodesecurePayload,
+      [
+        new Extractors.Probes.Licenses()
+      ]
+    );
+
+    const error = new Error("Listener error");
+    extractor.on("packument", () => {
+      throw error;
+    });
+
+    const packumentListenerErrors: Error[] = [];
+
+    extractor.onError((error) => {
+      packumentListenerErrors.push(error.cause as Error);
+    });
+
+    extractor.extract();
+
+    const expectedPackumentListenerErrors = packumentListenerErrors.map(() => error);
+    assert.deepEqual(packumentListenerErrors, expectedPackumentListenerErrors);
+  });
 });
 
 describe("Extractors.Callbacks", () => {


### PR DESCRIPTION
context:
event target dispatch erros through process.nextTick, so the engine treats as an asynchronous operation that leads to unwanted warning during unit tests by test runner.

fix:
try catch error and log it at payload level
<img width="966" height="174" alt="image" src="https://github.com/user-attachments/assets/0abcfdf4-d00e-4344-a927-7764c1b83a75" />


