### PR TITLE
fix(scanner): support string format for 'repository' field in comparePayloads

### DIFF
--- a/.changeset/extra-files-count.md
+++ b/.changeset/extra-files-count.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/scanner": patch
+---
+
+fix: support string format for 'repository' field in comparePayloads

--- a/workspaces/scanner/src/types.ts
+++ b/workspaces/scanner/src/types.ts
@@ -67,7 +67,7 @@ export interface DependencyVersion {
   /** Author of the package. This information is not trustable and can be empty. */
   author: Maintainer | null;
   engines: Engines;
-  repository?: Repository;
+  repository?: Repository | string;
   scripts: Record<string, string>;
   /**
    * JS-X-Ray warnings


### PR DESCRIPTION
**Closes #623**