### PR TITLE
fix(scanner): prioritize repository over homepage in getLinks

### DIFF
--- a/.changeset/wacky-lizards-attack.md
+++ b/.changeset/wacky-lizards-attack.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/scanner": patch
+---
+
+Prioritize repository over homepage in package.json to generate repository link

--- a/workspaces/scanner/src/utils/getLinks.ts
+++ b/workspaces/scanner/src/utils/getLinks.ts
@@ -44,8 +44,8 @@ export function getLinks(
     npm: `https://www.npmjs.com/package/${packumentVersion.name}/v/${packumentVersion.version}`,
     homepage,
     repository:
-      getVCSRepositoryURL(homepage) ??
-      getVCSRepositoryURL(repositoryUrl)
+      getVCSRepositoryURL(repositoryUrl) ??
+      getVCSRepositoryURL(homepage)
   };
 }
 
@@ -61,7 +61,7 @@ export function getManifestLinks(
     npm: null,
     homepage,
     repository:
-      getVCSRepositoryURL(homepage) ??
-      getVCSRepositoryURL(repositoryUrl)
+      getVCSRepositoryURL(repositoryUrl) ??
+      getVCSRepositoryURL(homepage)
   };
 }

--- a/workspaces/scanner/test/utils/getLinks.spec.ts
+++ b/workspaces/scanner/test/utils/getLinks.spec.ts
@@ -44,10 +44,27 @@ describe("utils.getLinks", () => {
         type: "git",
         url: "github.com/foo/bar"
       }
-    } as any), {
+    } as PackumentVersion), {
       npm: "https://www.npmjs.com/package/foo/v/1.0.0",
       homepage: "https://github.com/foo/bar",
       repository: "https://github.com/foo/bar"
+    });
+  });
+
+  it("repository url should prioritize repository over homepage", () => {
+    assert.deepStrictEqual(utils.getLinks({
+      name: "@nodesecure/utils",
+      version: "2.3.0",
+      homepage: "https://github.com/NodeSecure/tree/master/workspaces/utils#readme",
+      repository: {
+        type: "git",
+        url: "https://github.com/NodeSecure/scanner",
+        directory: "workspaces/utils"
+      }
+    } as PackumentVersion), {
+      npm: "https://www.npmjs.com/package/@nodesecure/utils/v/2.3.0",
+      homepage: "https://github.com/NodeSecure/tree/master/workspaces/utils#readme",
+      repository: "https://github.com/NodeSecure/scanner"
     });
   });
 });
@@ -92,6 +109,23 @@ describe("utils.getManifestLinks", () => {
       npm: null,
       homepage: null,
       repository: "https://github.com/foo/bar"
+    });
+  });
+
+  it("repository url should prioritize repository over homepage", () => {
+    assert.deepStrictEqual(utils.getManifestLinks({
+      name: "@nodesecure/utils",
+      version: "2.3.0",
+      homepage: "https://github.com/NodeSecure/tree/master/workspaces/utils#readme",
+      repository: {
+        type: "git",
+        url: "https://github.com/NodeSecure/scanner",
+        directory: "workspaces/utils"
+      }
+    }), {
+      npm: null,
+      homepage: "https://github.com/NodeSecure/tree/master/workspaces/utils#readme",
+      repository: "https://github.com/NodeSecure/scanner"
     });
   });
 });


### PR DESCRIPTION
`getLinks`prioritized homepage over repository to resolve the VCS URL. For package like `@nodesecure/utils`, the homepage field points to a subfolder path:                                         

```json
{
  "homepage": "https://github.com/NodeSecure/tree/master/workspaces/utils#readme",                          
  "repository": {                                                                                           
    "type": "git",
    "url": "https://github.com/NodeSecure/scanner"                                                          
  }
}
```                                                                                                         

`getVCSRepositoryURL` parsed the homepage URL and extracted only [owner, repo] from the pathname, producing `https://github.com/NodeSecure/tree` instead of `https://github.com/NodeSecure/scanner`.

Similar to https://github.com/NodeSecure/ossf-scorecard-sdk/pull/89