### PR TITLE
fix(tree-walker): LocalDependencyTreeLoader fails resolving symlink l…

### DIFF
--- a/.changeset/busy-pianos-dress.md
+++ b/.changeset/busy-pianos-dress.md
@@ -1,0 +1,5 @@
+---
+"@nodesecure/tree-walker": patch
+---
+
+fix(tree-walker): LocalDependencyTreeLoader fails resolving symlink location on macos

--- a/workspaces/scanner/test/depWalker.spec.ts
+++ b/workspaces/scanner/test/depWalker.spec.ts
@@ -196,7 +196,7 @@ describe("depWalker", { concurrency: 2 }, () => {
       { path: "EntryFileAnalyser", filesCount: 17 },
       { path: "EntryFileAnalyser", filesCount: 47 },
       { path: "EntryFileAnalyser", filesCount: 67 },
-      { path: "EntryFileAnalyser", filesCount: 210 }].sort(byFilesCount));
+      { path: "EntryFileAnalyser", filesCount: 214 }].sort(byFilesCount));
   });
 
   function byFilesCount<T extends { filesCount: number; } | undefined>(a: T, b: T) {

--- a/workspaces/tree-walker/src/npm/LocalDependencyTreeLoader.ts
+++ b/workspaces/tree-walker/src/npm/LocalDependencyTreeLoader.ts
@@ -29,23 +29,26 @@ export class LocalDependencyTreeLoader implements LocalDependencyTreeLoaderProvi
     options: LocalDependencyTreeLoaderOptions = {}
   ): Promise<TreeDependencies> {
     const { registry, ...treeDepOptions } = options;
+    const resolvedLocation = await fs.realpath(location);
 
     const arb = new Arborist({
       ...utils.NPM_TOKEN,
-      path: location,
+      path: resolvedLocation,
       registry
     });
 
     try {
       await fs.access(
-        path.join(location, "node_modules")
+        path.join(resolvedLocation, "node_modules")
       );
 
       await arb.loadActual();
 
-      const treeNode = await arb.buildIdealTree();
+      if (!arb.actualTree) {
+        throw new Error("arborist loadActual fn did not produce a tree");
+      }
 
-      return TreeDependencies.fromArboristNode(treeNode, treeDepOptions);
+      return TreeDependencies.fromArboristNode(arb.actualTree, treeDepOptions);
     }
     catch {
       const treeNode = await arb.loadVirtual();


### PR DESCRIPTION
## bug
LocalDependencyTreeLoader.load() was failing on macOS by returning an empty dependency tree.

## cause:
On macOS, os.tmpdir() returns /var/folders/..., which is a symlink to /private/var/folders/...
 
## consequence: 
two root nodes in the Arborist inventory, the incorrect one of which was referenced by arb.actualTree.

## why this fix?
The only place where realpath should be used is in LocalDependencyTreeLoader, which communicates with Arborist. it is responsible for ensuring path consistency.