### PR TITLE
chore(engine): use the CI matrix minimum as required engine

### DIFF
--- a/workspaces/conformance/package.json
+++ b/workspaces/conformance/package.json
@@ -6,7 +6,7 @@
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -b",

--- a/workspaces/contact/package.json
+++ b/workspaces/contact/package.json
@@ -13,7 +13,7 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -b",

--- a/workspaces/flags/package.json
+++ b/workspaces/flags/package.json
@@ -54,6 +54,6 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/workspaces/fs-walk/package.json
+++ b/workspaces/fs-walk/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/workspaces/github/package.json
+++ b/workspaces/github/package.json
@@ -45,6 +45,6 @@
     "@types/tar-fs": "^2.0.4"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/workspaces/gitlab/package.json
+++ b/workspaces/gitlab/package.json
@@ -44,6 +44,6 @@
     "@types/tar-fs": "^2.0.4"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/workspaces/i18n/package.json
+++ b/workspaces/i18n/package.json
@@ -41,7 +41,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@nodesecure/js-x-ray": "16.0.0",

--- a/workspaces/rc/package.json
+++ b/workspaces/rc/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -b",

--- a/workspaces/scanner/package.json
+++ b/workspaces/scanner/package.json
@@ -15,7 +15,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -b && cp -R ./src/data ./dist/data",

--- a/workspaces/utils/package.json
+++ b/workspaces/utils/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
--test-only use glob pattern that needs node v22 to works so local engine >=20 does not work and is not mirror as CI matrix so all PR pass while they fail locally.